### PR TITLE
Allow incloming correlation_id propagation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.ge.predix</groupId>
     <artifactId>spring-log-filter</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <name>Predix Spring Log Filter</name>
     <description>This library provides a spring filter that generates correlation ids to help trace issues in log files.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/ge/predix/log/filter/LogFilter.java
+++ b/src/main/java/com/ge/predix/log/filter/LogFilter.java
@@ -87,8 +87,11 @@ public class LogFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response,
             final FilterChain filterChain) throws ServletException, IOException {
-
-        String correlationId = UUID.randomUUID().toString();
+        String correlationId = request.getHeader(LOG_CORRELATION_ID);
+        if (StringUtils.isEmpty(correlationId)) {
+            correlationId = UUID.randomUUID().toString();
+        }
+        
         put(LOG_CORRELATION_ID, correlationId);
         response.setHeader(LOG_CORRELATION_ID, correlationId);
 

--- a/src/test/java/com/ge/predix/log/filter/LogFilterTest.java
+++ b/src/test/java/com/ge/predix/log/filter/LogFilterTest.java
@@ -16,8 +16,11 @@
 package com.ge.predix.log.filter;
 
 import java.util.LinkedHashSet;
+import java.util.UUID;
 
+import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -129,4 +132,26 @@ public class LogFilterTest {
         Assert.assertEquals(logFilter.getHostnames().toString(), "[localhost]");
         Assert.assertEquals(logFilter.getZoneHeaders().toString(), "[X-Identity-Zone-Id, Predix-Zone-Id]");
     }
+    
+    @Test
+    public void testLogFilterWithCorrelationIdHeader() throws Exception {
+        LogFilter logFilter = new LogFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String requestCorrelationId = UUID.randomUUID().toString();
+        request.addHeader("Correlation-Id", requestCorrelationId);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        logFilter.doFilter(request, response, new MockFilterChain());
+        String responseCorrelationId = response.getHeader("Correlation-Id");
+        Assert.assertEquals(requestCorrelationId, responseCorrelationId);
+    }
+
+    @Test
+    public void testLogFilterWithoutCorrelationIdHeader() throws Exception {
+        LogFilter logFilter = new LogFilter();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        logFilter.doFilter(new MockHttpServletRequest(), response, new MockFilterChain());
+        String responseCorrelationId = response.getHeader("Correlation-Id");
+        Assert.assertNotNull(responseCorrelationId);
+    }
+
 }


### PR DESCRIPTION
Making sure that incoming correlation id header is used if provided