### PR TITLE
add app name as optional parameter to log filter bean

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ Utility filter for tracing, log enrichment and auditing.
 This filter initializes an HTTP header(X-B3-TraceID) for tracing, if not already present. The header is also added in the outgoing response.
 * Note that if you are already using another library for propogating headers, this will have no effect.
 
-## 2. Provides log4j 1 layout for Predix log format
+## 2. Provides log4j1 layout and logback encoder for Predix log format
+Where?
+* Logback Encoder [PredixEncoder.java](src/main/java/com/ge/predix/logback/PredixEncoder.java)
+* Log4j1 layout [PredixLayoutPattern.java](src/main/java/com/ge/predix/log4j1/PredixLayoutPattern.java)
+
+What?
+
 This layout formats the log in JSON and includes the cloudfoundry VCAP info listed in the section above.
 Sample log message:
 ![](docs/sample-json-log.png)
@@ -18,6 +24,7 @@ Sample log message:
           APP_NAME
           INSTANCE_ID
       ```
+      * APP_NAME value can be customized using LogFilter.setCustomAppName
     * It also adds the following from HTTP headers:
       ```
           X-B3-TraceId

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.ge.predix</groupId>
     <artifactId>spring-log-filter</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <name>Predix Spring Log Filter</name>
     <description>This library provides a spring filter that generates correlation ids to help trace issues in log files.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/ge/predix/log/filter/LogFilter.java
+++ b/src/main/java/com/ge/predix/log/filter/LogFilter.java
@@ -42,7 +42,6 @@ import com.ge.predix.vcap.VcapApplication;
 public class LogFilter extends OncePerRequestFilter {
 
     private static final String APP_ID = "APP_ID";
-    private static final String VCAP_APP_NAME = "VCAP_APP_NAME";
     private static final String APP_NAME = "APP_NAME";
     private static final String INSTANCE_ID = "INSTANCE_ID";
     private static final String INSTANCE_INDEX = "INSTANCE_INDEX";
@@ -144,7 +143,6 @@ public class LogFilter extends OncePerRequestFilter {
     private void clearMDC() {
         MDC.remove(APP_ID);
         MDC.remove(APP_NAME);
-        MDC.remove(VCAP_APP_NAME);
         MDC.remove(INSTANCE_ID);
         MDC.remove(INSTANCE_INDEX);
         MDC.remove(ZONE_HEADER_NAME);
@@ -154,13 +152,14 @@ public class LogFilter extends OncePerRequestFilter {
     private void addAppNameToMDC() {
         if (customAppName != null) {
             MDC.put(APP_NAME, customAppName);
+        } else {
+            MDC.put(APP_NAME, this.vcapApplication.getAppName());
         }
     }
 
     private void addVcapToMDC() {
         if (this.vcapApplication != null) {
             MDC.put(APP_ID, this.vcapApplication.getAppId());
-            MDC.put(VCAP_APP_NAME, this.vcapApplication.getAppName());
             MDC.put(INSTANCE_ID, this.vcapApplication.getInstanceId());
             MDC.put(INSTANCE_INDEX, this.vcapApplication.getInstanceIndex());
         }

--- a/src/main/java/com/ge/predix/log/filter/LogFilter.java
+++ b/src/main/java/com/ge/predix/log/filter/LogFilter.java
@@ -42,6 +42,7 @@ import com.ge.predix.vcap.VcapApplication;
 public class LogFilter extends OncePerRequestFilter {
 
     private static final String APP_ID = "APP_ID";
+    private static final String VCAP_APP_NAME = "VCAP_APP_NAME";
     private static final String APP_NAME = "APP_NAME";
     private static final String INSTANCE_ID = "INSTANCE_ID";
     private static final String INSTANCE_INDEX = "INSTANCE_INDEX";
@@ -50,6 +51,8 @@ public class LogFilter extends OncePerRequestFilter {
 
     @Value("${VCAP_APPLICATION:}")
     private String vcapApplicationEnvJson;
+    
+    private String customAppName;
 
     @Autowired(required = false)
     private AuditEventProcessor auditProcessor;
@@ -118,6 +121,7 @@ public class LogFilter extends OncePerRequestFilter {
             String correlationId = setCorrelationId(request, response);
             String zoneId = setZoneId(request);
             addVcapToMDC();
+            addAppNameToMDC();
             if (null == this.auditProcessor) {
                 filterChain.doFilter(request, response);
             } else {
@@ -140,16 +144,23 @@ public class LogFilter extends OncePerRequestFilter {
     private void clearMDC() {
         MDC.remove(APP_ID);
         MDC.remove(APP_NAME);
+        MDC.remove(VCAP_APP_NAME);
         MDC.remove(INSTANCE_ID);
         MDC.remove(INSTANCE_INDEX);
         MDC.remove(ZONE_HEADER_NAME);
         MDC.remove(CORRELATION_HEADER_NAME);
     }
+    
+    private void addAppNameToMDC() {
+        if (customAppName != null) {
+            MDC.put(APP_NAME, customAppName);
+        }
+    }
 
     private void addVcapToMDC() {
         if (this.vcapApplication != null) {
             MDC.put(APP_ID, this.vcapApplication.getAppId());
-            MDC.put(APP_NAME, this.vcapApplication.getAppName());
+            MDC.put(VCAP_APP_NAME, this.vcapApplication.getAppName());
             MDC.put(INSTANCE_ID, this.vcapApplication.getInstanceId());
             MDC.put(INSTANCE_INDEX, this.vcapApplication.getInstanceIndex());
         }
@@ -210,6 +221,15 @@ public class LogFilter extends OncePerRequestFilter {
     
     public void setAuditProcessor(final AuditEventProcessor auditProcessor) {
         this.auditProcessor = auditProcessor;
+    }
+    
+
+    public String getCustomAppName() {
+        return customAppName;
+    }
+
+    public void setCustomAppName(final String customAppName) {
+        this.customAppName = customAppName;
     }
 
     

--- a/src/main/java/com/ge/predix/log/filter/LogFilter.java
+++ b/src/main/java/com/ge/predix/log/filter/LogFilter.java
@@ -152,7 +152,7 @@ public class LogFilter extends OncePerRequestFilter {
     private void addAppNameToMDC() {
         if (customAppName != null) {
             MDC.put(APP_NAME, customAppName);
-        } else {
+        } else if (this.vcapApplication != null) {
             MDC.put(APP_NAME, this.vcapApplication.getAppName());
         }
     }

--- a/src/main/java/com/ge/predix/log4j1/PredixLayoutPattern.java
+++ b/src/main/java/com/ge/predix/log4j1/PredixLayoutPattern.java
@@ -30,12 +30,11 @@ public class PredixLayoutPattern extends PatternConverter {
     protected String convert(final LoggingEvent event) {
         // need LinkedHashMap to preserve order of log fields
         Map<String, Object> logFormat = new LinkedHashMap<>();
-        Object appName = event.getMDC("APP_NAME") != null ? event.getMDC("APP_NAME") : event.getMDC("VCAP_APP_NAME");
 
         logFormat.put("time", ISO_DATE_FORMAT.format(new Date(event.getTimeStamp())));
         logFormat.put("tnt", event.getMDC("Zone-Id"));
         logFormat.put("corr", event.getMDC("X-B3-TraceId"));
-        logFormat.put("appn", appName);
+        logFormat.put("appn", event.getMDC("APP_NAME"));
         logFormat.put("dpmt", event.getMDC("APP_ID"));
         logFormat.put("inst", event.getMDC("INSTANCE_ID"));
         logFormat.put("tid", event.getThreadName());

--- a/src/main/java/com/ge/predix/log4j1/PredixLayoutPattern.java
+++ b/src/main/java/com/ge/predix/log4j1/PredixLayoutPattern.java
@@ -30,10 +30,12 @@ public class PredixLayoutPattern extends PatternConverter {
     protected String convert(final LoggingEvent event) {
         // need LinkedHashMap to preserve order of log fields
         Map<String, Object> logFormat = new LinkedHashMap<>();
+        Object appName = event.getMDC("APP_NAME") != null ? event.getMDC("APP_NAME") : event.getMDC("VCAP_APP_NAME");
+
         logFormat.put("time", ISO_DATE_FORMAT.format(new Date(event.getTimeStamp())));
         logFormat.put("tnt", event.getMDC("Zone-Id"));
         logFormat.put("corr", event.getMDC("X-B3-TraceId"));
-        logFormat.put("appn", event.getMDC("APP_NAME"));
+        logFormat.put("appn", appName);
         logFormat.put("dpmt", event.getMDC("APP_ID"));
         logFormat.put("inst", event.getMDC("INSTANCE_ID"));
         logFormat.put("tid", event.getThreadName());

--- a/src/main/java/com/ge/predix/logback/PredixEncoder.java
+++ b/src/main/java/com/ge/predix/logback/PredixEncoder.java
@@ -34,15 +34,13 @@ public class PredixEncoder<E extends ILoggingEvent> extends EncoderBase<E> {
     @Override
     public void doEncode(final E event) throws IOException {
         Map<String, String> mdc = event.getMDCPropertyMap();
-        Object appName = mdc.get("APP_NAME") != null ? mdc.get("APP_NAME") : mdc.getOrDefault("VCAP_APP_NAME", "");
-
 
         // need LinkedHashMap to preserve order of log fields
         Map<String, Object> logFormat = new LinkedHashMap<>();
         logFormat.put("time", ISO_DATE_FORMAT.format(new Date(event.getTimeStamp())));
         logFormat.put("tnt", mdc.getOrDefault("Zone-Id", ""));
         logFormat.put("corr", mdc.getOrDefault("X-B3-TraceId", ""));
-        logFormat.put("appn", appName);
+        logFormat.put("appn", mdc.get("APP_NAME"));
         logFormat.put("dpmt", mdc.getOrDefault("APP_ID", ""));
         logFormat.put("inst", mdc.getOrDefault("INSTANCE_ID", ""));
         logFormat.put("tid", event.getThreadName());

--- a/src/main/java/com/ge/predix/logback/PredixEncoder.java
+++ b/src/main/java/com/ge/predix/logback/PredixEncoder.java
@@ -34,13 +34,15 @@ public class PredixEncoder<E extends ILoggingEvent> extends EncoderBase<E> {
     @Override
     public void doEncode(final E event) throws IOException {
         Map<String, String> mdc = event.getMDCPropertyMap();
+        Object appName = mdc.get("APP_NAME") != null ? mdc.get("APP_NAME") : mdc.getOrDefault("VCAP_APP_NAME", "");
+
 
         // need LinkedHashMap to preserve order of log fields
         Map<String, Object> logFormat = new LinkedHashMap<>();
         logFormat.put("time", ISO_DATE_FORMAT.format(new Date(event.getTimeStamp())));
         logFormat.put("tnt", mdc.getOrDefault("Zone-Id", ""));
         logFormat.put("corr", mdc.getOrDefault("X-B3-TraceId", ""));
-        logFormat.put("appn", mdc.getOrDefault("APP_NAME", ""));
+        logFormat.put("appn", appName);
         logFormat.put("dpmt", mdc.getOrDefault("APP_ID", ""));
         logFormat.put("inst", mdc.getOrDefault("INSTANCE_ID", ""));
         logFormat.put("tid", event.getThreadName());

--- a/src/test/java/com/ge/predix/log/filter/LogFilterTest.java
+++ b/src/test/java/com/ge/predix/log/filter/LogFilterTest.java
@@ -21,12 +21,15 @@ import static org.mockito.Matchers.any;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 
+import org.apache.log4j.MDC;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -187,6 +190,19 @@ public class LogFilterTest {
         logFilter.doFilter(new MockHttpServletRequest(), response, new MockFilterChain());
         String responseCorrelationId = response.getHeader("X-B3-TraceId");
         Assert.assertNotNull(responseCorrelationId);
+    }
+
+    @Test
+    public void testLogFilterWithCustomAppName() throws Exception {
+        LogFilter logFilter = new LogFilter();
+        String appName = "custom app name";
+        logFilter.setCustomAppName(appName);
+        Map<String, String> expectMap = new HashMap<String, String>();
+        expectMap.put("APP_NAME", "custom app name");
+        
+        Servlet mockServlet = Mockito.mock(Servlet.class);
+
+        logFilter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), new MockFilterChain(mockServlet, new MockMDCFilter(expectMap)));
     }
 
     @Test

--- a/src/test/java/com/ge/predix/log/filter/MockMDCFilter.java
+++ b/src/test/java/com/ge/predix/log/filter/MockMDCFilter.java
@@ -1,0 +1,38 @@
+package com.ge.predix.log.filter;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import junit.framework.Assert;
+
+//this filter is used in the testLogFilterAudit to test MDC values are set correctly
+public class MockMDCFilter extends OncePerRequestFilter {
+
+    private Map<String, String> expectMap;
+
+    public MockMDCFilter(Map<String, String> expectMap) {
+        super();
+        this.expectMap = expectMap;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest paramHttpServletRequest,
+            HttpServletResponse paramHttpServletResponse, FilterChain paramFilterChain)
+            throws ServletException, IOException {
+        
+        for(String key : expectMap.keySet()) {
+            Assert.assertEquals(expectMap.get(key), MDC.get(key));
+        }
+        
+        paramFilterChain.doFilter(paramHttpServletRequest, paramHttpServletResponse);
+    }
+
+}

--- a/src/test/java/com/ge/predix/log4j1/PredixLayoutTest.java
+++ b/src/test/java/com/ge/predix/log4j1/PredixLayoutTest.java
@@ -20,13 +20,12 @@ public class PredixLayoutTest {
 
     private static final String APP_ID = "APP_ID";
     private static final String APP_NAME = "APP_NAME";
-    private static final String VCAP_APP_NAME = "VCAP_APP_NAME";
     private static final String INSTANCE_ID = "INSTANCE_ID";
     private static final String INSTANCE_INDEX = "INSTANCE_INDEX";
     private static final String INSTANCE_ID_VALUE = "6758302";
     private static final String ZONE_VALUE = "test-zone";
     private static final String INSTANCE_INDEX_VALUE = "5";
-    private static final String VCAP_APP_NAME_VALUE = "uaa";
+    private static final String APP_NAME_VALUE = "uaa";
     private static final String APP_ID_VALUE = "098877475";
     private static final String CORRELATION_VALUE = "5678";
     private static final String FILE_NAME = "test.java";
@@ -56,33 +55,13 @@ public class PredixLayoutTest {
                 info, mdc);
         String actual = predixLayout.format(logEvent);
         String expected = "{\"time\":\"" + expectedTimeStamp +"\",\"tnt\":\"" + ZONE_VALUE +"\",\"corr\":\"" 
-        + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
+        + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
                 + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME + "\",\"lvl\":\""
                 + Level.INFO.toString() + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5}}\n";
         System.out.println(actual);
         Assert.assertEquals(expected, actual);
     }
     
-
-    @Test
-    public void testPredixLayoutCustomAppNameLog() throws IOException {
-        LocationInfo info = new LocationInfo(FILE_NAME, CLASS_NAME, METHOD_NAME, LINE_NUMBER);
-        long timeStamp = Instant.now().toEpochMilli();
-        String expectedTimeStamp = this.simpleDateFormat.format(new Date(timeStamp));
-        HashMap<String, String> mdc = getMDC();
-        String customAppName = "otherName";
-        mdc.put(APP_NAME, customAppName);
-        HashMap<String, Object> msg = getMsg();
-        LoggingEvent logEvent = new LoggingEvent(FILE_NAME, null, timeStamp, Level.INFO, msg, THREAD_NAME, null, "ndc",
-                info, mdc);
-        String actual = predixLayout.format(logEvent);
-        String expected = "{\"time\":\"" + expectedTimeStamp +"\",\"tnt\":\"" + ZONE_VALUE +"\",\"corr\":\"" 
-        + CORRELATION_VALUE + "\",\"appn\":\"" + customAppName + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
-                + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME + "\",\"lvl\":\""
-                + Level.INFO.toString() + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5}}\n";
-        System.out.println(actual);
-        Assert.assertEquals(expected, actual);
-    }
 
     @Test
     public void testPredixLayoutSpecialCharsLog() throws IOException {
@@ -97,7 +76,7 @@ public class PredixLayoutTest {
                 info, mdc);
         String actual = predixLayout.format(logEvent);
         String expected = "{\"time\":\"" + expectedTimeStamp +"\",\"tnt\":\"" + ZONE_VALUE +"\",\"corr\":\"" 
-        + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
+        + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
                 + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME + "\",\"lvl\":\""
                 + Level.INFO.toString() + "\",\"msg\":{\"quote\":\"\\\"\",\"backslash\":\"\\\\\"}}\n";
         Assert.assertEquals(expected, actual);
@@ -121,7 +100,7 @@ public class PredixLayoutTest {
                 "ndc", info, mdc);
         String actual = predixLayout.format(logEvent);
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.ERROR.toString()
                 + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5},\"stck\":"
@@ -133,7 +112,7 @@ public class PredixLayoutTest {
                 msg, THREAD_NAME, null, "ndc", info, mdc);
         actual = predixLayout.format(logEvent);
         expected = "{\"time\":\"" + expectedTimeStamp +"\",\"tnt\":\"" + ZONE_VALUE +"\",\"corr\":\"" 
-        + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
+        + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
                 + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME + "\",\"lvl\":\""
                 + Level.INFO.toString() + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5}}\n";
         Assert.assertEquals(expected, actual);
@@ -164,7 +143,7 @@ public class PredixLayoutTest {
         String actual = predixLayout.format(logEvent);
 
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.ERROR.toString()
                 + "\",\"msg\":\"{width=4, length=3, units=inches, height=5}\",\"stck\":["
@@ -187,7 +166,7 @@ public class PredixLayoutTest {
         String actual = predixLayout.format(logEvent);
         System.out.println(actual);
         String expected = "{\"time\":\"" + expectedTimeStamp +"\",\"tnt\":\"" + ZONE_VALUE +"\",\"corr\":\"" 
-        + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
+        + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
                 + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"?\",\"msg\":null}\n";
         Assert.assertEquals(expected, actual);
     }
@@ -205,7 +184,7 @@ public class PredixLayoutTest {
         HashMap<String, String> mdc = new HashMap<>();
         mdc.put(CORRELATION_HEADER, CORRELATION_VALUE);
         mdc.put(APP_ID, APP_ID_VALUE);
-        mdc.put(VCAP_APP_NAME, VCAP_APP_NAME_VALUE);
+        mdc.put(APP_NAME, APP_NAME_VALUE);
         mdc.put(INSTANCE_ID, INSTANCE_ID_VALUE);
         mdc.put(INSTANCE_INDEX, INSTANCE_INDEX_VALUE);
         mdc.put(ZONE_HEADER, ZONE_VALUE);

--- a/src/test/java/com/ge/predix/log4j1/PredixLayoutTest.java
+++ b/src/test/java/com/ge/predix/log4j1/PredixLayoutTest.java
@@ -20,12 +20,13 @@ public class PredixLayoutTest {
 
     private static final String APP_ID = "APP_ID";
     private static final String APP_NAME = "APP_NAME";
+    private static final String VCAP_APP_NAME = "VCAP_APP_NAME";
     private static final String INSTANCE_ID = "INSTANCE_ID";
     private static final String INSTANCE_INDEX = "INSTANCE_INDEX";
     private static final String INSTANCE_ID_VALUE = "6758302";
     private static final String ZONE_VALUE = "test-zone";
     private static final String INSTANCE_INDEX_VALUE = "5";
-    private static final String APP_NAME_VALUE = "uaa";
+    private static final String VCAP_APP_NAME_VALUE = "uaa";
     private static final String APP_ID_VALUE = "098877475";
     private static final String CORRELATION_VALUE = "5678";
     private static final String FILE_NAME = "test.java";
@@ -55,7 +56,28 @@ public class PredixLayoutTest {
                 info, mdc);
         String actual = predixLayout.format(logEvent);
         String expected = "{\"time\":\"" + expectedTimeStamp +"\",\"tnt\":\"" + ZONE_VALUE +"\",\"corr\":\"" 
-        + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
+        + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
+                + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME + "\",\"lvl\":\""
+                + Level.INFO.toString() + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5}}\n";
+        System.out.println(actual);
+        Assert.assertEquals(expected, actual);
+    }
+    
+
+    @Test
+    public void testPredixLayoutCustomAppNameLog() throws IOException {
+        LocationInfo info = new LocationInfo(FILE_NAME, CLASS_NAME, METHOD_NAME, LINE_NUMBER);
+        long timeStamp = Instant.now().toEpochMilli();
+        String expectedTimeStamp = this.simpleDateFormat.format(new Date(timeStamp));
+        HashMap<String, String> mdc = getMDC();
+        String customAppName = "otherName";
+        mdc.put(APP_NAME, customAppName);
+        HashMap<String, Object> msg = getMsg();
+        LoggingEvent logEvent = new LoggingEvent(FILE_NAME, null, timeStamp, Level.INFO, msg, THREAD_NAME, null, "ndc",
+                info, mdc);
+        String actual = predixLayout.format(logEvent);
+        String expected = "{\"time\":\"" + expectedTimeStamp +"\",\"tnt\":\"" + ZONE_VALUE +"\",\"corr\":\"" 
+        + CORRELATION_VALUE + "\",\"appn\":\"" + customAppName + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
                 + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME + "\",\"lvl\":\""
                 + Level.INFO.toString() + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5}}\n";
         System.out.println(actual);
@@ -75,7 +97,7 @@ public class PredixLayoutTest {
                 info, mdc);
         String actual = predixLayout.format(logEvent);
         String expected = "{\"time\":\"" + expectedTimeStamp +"\",\"tnt\":\"" + ZONE_VALUE +"\",\"corr\":\"" 
-        + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
+        + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
                 + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME + "\",\"lvl\":\""
                 + Level.INFO.toString() + "\",\"msg\":{\"quote\":\"\\\"\",\"backslash\":\"\\\\\"}}\n";
         Assert.assertEquals(expected, actual);
@@ -99,7 +121,7 @@ public class PredixLayoutTest {
                 "ndc", info, mdc);
         String actual = predixLayout.format(logEvent);
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.ERROR.toString()
                 + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5},\"stck\":"
@@ -111,7 +133,7 @@ public class PredixLayoutTest {
                 msg, THREAD_NAME, null, "ndc", info, mdc);
         actual = predixLayout.format(logEvent);
         expected = "{\"time\":\"" + expectedTimeStamp +"\",\"tnt\":\"" + ZONE_VALUE +"\",\"corr\":\"" 
-        + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
+        + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
                 + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME + "\",\"lvl\":\""
                 + Level.INFO.toString() + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5}}\n";
         Assert.assertEquals(expected, actual);
@@ -142,7 +164,7 @@ public class PredixLayoutTest {
         String actual = predixLayout.format(logEvent);
 
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.ERROR.toString()
                 + "\",\"msg\":\"{width=4, length=3, units=inches, height=5}\",\"stck\":["
@@ -165,7 +187,7 @@ public class PredixLayoutTest {
         String actual = predixLayout.format(logEvent);
         System.out.println(actual);
         String expected = "{\"time\":\"" + expectedTimeStamp +"\",\"tnt\":\"" + ZONE_VALUE +"\",\"corr\":\"" 
-        + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
+        + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\""
                 + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"?\",\"msg\":null}\n";
         Assert.assertEquals(expected, actual);
     }
@@ -183,7 +205,7 @@ public class PredixLayoutTest {
         HashMap<String, String> mdc = new HashMap<>();
         mdc.put(CORRELATION_HEADER, CORRELATION_VALUE);
         mdc.put(APP_ID, APP_ID_VALUE);
-        mdc.put(APP_NAME, APP_NAME_VALUE);
+        mdc.put(VCAP_APP_NAME, VCAP_APP_NAME_VALUE);
         mdc.put(INSTANCE_ID, INSTANCE_ID_VALUE);
         mdc.put(INSTANCE_INDEX, INSTANCE_INDEX_VALUE);
         mdc.put(ZONE_HEADER, ZONE_VALUE);

--- a/src/test/java/com/ge/predix/logback/PredixEncoderTest.java
+++ b/src/test/java/com/ge/predix/logback/PredixEncoderTest.java
@@ -25,13 +25,13 @@ import ch.qos.logback.classic.spi.ThrowableProxy;
 public class PredixEncoderTest {
 
     private static final String APP_ID = "APP_ID";
-    private static final String VCAP_APP_NAME = "VCAP_APP_NAME";
+    private static final String APP_NAME = "APP_NAME";
     private static final String INSTANCE_ID = "INSTANCE_ID";
     private static final String INSTANCE_INDEX = "INSTANCE_INDEX";
     private static final String INSTANCE_ID_VALUE = "6758302";
     private static final String ZONE_VALUE = "test-zone";
     private static final String INSTANCE_INDEX_VALUE = "5";
-    private static final String VCAP_APP_NAME_VALUE = "uaa";
+    private static final String APP_NAME_VALUE = "uaa";
     private static final String APP_ID_VALUE = "098877475";
     private static final String CORRELATION_VALUE = "5678";
     private static final String FILE_NAME = "test.java";
@@ -69,7 +69,7 @@ public class PredixEncoderTest {
         this.predixLayout.doEncode(logEvent);
         String actual = baos.toString();
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.INFO.toString()
                 + "\",\"msg\":\"{width=4, length=3, units=inches, height=5}\"}";
@@ -95,35 +95,7 @@ public class PredixEncoderTest {
         this.predixLayout.doEncode(logEvent);
         String actual = baos.toString();
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
-                + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
-                + "\",\"lvl\":\"" + Level.INFO.toString() + "\",\"msg\":\"\\\"{}\\n,\\\"\\\\\"}";
-        Assert.assertEquals(expected, actual);
-    }
-    
-    @Test
-    public void testPredixLayoutCustomAppName() throws IOException {
-        StackTraceElement[] caller = { new StackTraceElement(CLASS_NAME, METHOD_NAME, FILE_NAME, LINE_NUMBER) };
-        long timeStamp = Instant.now().toEpochMilli();
-        String expectedTimeStamp = this.simpleDateFormat.format(new Date(timeStamp));
-        HashMap<String, String> mdc = getMDC();
-        String msg = "\"{}\n,\"\\";
-        Logger logger = new LoggerContext().getLogger(PredixEncoder.class);
-        LoggingEvent logEvent = new LoggingEvent(CLASS_NAME, logger, Level.INFO, msg.toString(), null, null);
-        logEvent.setMDCPropertyMap(mdc);
-        logEvent.setThreadName("Thread1");
-        logEvent.setCallerData(caller);
-        
-        String customAppName = "otherName";
-        logEvent.setTimeStamp(timeStamp);
-        mdc.put(VCAP_APP_NAME, customAppName);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream os = new PrintStream(baos);
-        this.predixLayout.init(os);
-        this.predixLayout.doEncode(logEvent);
-        String actual = baos.toString();
-        String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + customAppName + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.INFO.toString() + "\",\"msg\":\"\\\"{}\\n,\\\"\\\\\"}";
         Assert.assertEquals(expected, actual);
@@ -155,7 +127,7 @@ public class PredixEncoderTest {
         String actual = baos.toString();
 
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.ERROR.toString()
                 + "\",\"msg\":\"{width=4, length=3, units=inches, height=5}\",\"stck\":"
@@ -195,7 +167,7 @@ public class PredixEncoderTest {
         String actual = baos.toString();
 
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.ERROR.toString()
                 + "\",\"msg\":\"{width=4, length=3, units=inches, height=5}\",\"stck\":["
@@ -224,7 +196,7 @@ public class PredixEncoderTest {
         this.predixLayout.doEncode(logEvent);
         String actual = baos.toString();
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME
                 + "\",\"mod\":\"?\",\"msg\":null}";
         Assert.assertEquals(expected, actual);
@@ -243,7 +215,7 @@ public class PredixEncoderTest {
         HashMap<String, String> mdc = new HashMap<>();
         mdc.put(CORRELATION_HEADER, CORRELATION_VALUE);
         mdc.put(APP_ID, APP_ID_VALUE);
-        mdc.put(VCAP_APP_NAME, VCAP_APP_NAME_VALUE);
+        mdc.put(APP_NAME, APP_NAME_VALUE);
         mdc.put(INSTANCE_ID, INSTANCE_ID_VALUE);
         mdc.put(INSTANCE_INDEX, INSTANCE_INDEX_VALUE);
         mdc.put(ZONE_HEADER, ZONE_VALUE);

--- a/src/test/java/com/ge/predix/logback/PredixEncoderTest.java
+++ b/src/test/java/com/ge/predix/logback/PredixEncoderTest.java
@@ -11,6 +11,7 @@ import java.util.TimeZone;
 
 import junit.framework.Assert;
 
+import org.apache.log4j.spi.LocationInfo;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,13 +25,13 @@ import ch.qos.logback.classic.spi.ThrowableProxy;
 public class PredixEncoderTest {
 
     private static final String APP_ID = "APP_ID";
-    private static final String APP_NAME = "APP_NAME";
+    private static final String VCAP_APP_NAME = "VCAP_APP_NAME";
     private static final String INSTANCE_ID = "INSTANCE_ID";
     private static final String INSTANCE_INDEX = "INSTANCE_INDEX";
     private static final String INSTANCE_ID_VALUE = "6758302";
     private static final String ZONE_VALUE = "test-zone";
     private static final String INSTANCE_INDEX_VALUE = "5";
-    private static final String APP_NAME_VALUE = "uaa";
+    private static final String VCAP_APP_NAME_VALUE = "uaa";
     private static final String APP_ID_VALUE = "098877475";
     private static final String CORRELATION_VALUE = "5678";
     private static final String FILE_NAME = "test.java";
@@ -68,7 +69,7 @@ public class PredixEncoderTest {
         this.predixLayout.doEncode(logEvent);
         String actual = baos.toString();
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.INFO.toString()
                 + "\",\"msg\":\"{width=4, length=3, units=inches, height=5}\"}";
@@ -94,12 +95,40 @@ public class PredixEncoderTest {
         this.predixLayout.doEncode(logEvent);
         String actual = baos.toString();
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.INFO.toString() + "\",\"msg\":\"\\\"{}\\n,\\\"\\\\\"}";
         Assert.assertEquals(expected, actual);
     }
-
+    
+    @Test
+    public void testPredixLayoutCustomAppName() throws IOException {
+        StackTraceElement[] caller = { new StackTraceElement(CLASS_NAME, METHOD_NAME, FILE_NAME, LINE_NUMBER) };
+        long timeStamp = Instant.now().toEpochMilli();
+        String expectedTimeStamp = this.simpleDateFormat.format(new Date(timeStamp));
+        HashMap<String, String> mdc = getMDC();
+        String msg = "\"{}\n,\"\\";
+        Logger logger = new LoggerContext().getLogger(PredixEncoder.class);
+        LoggingEvent logEvent = new LoggingEvent(CLASS_NAME, logger, Level.INFO, msg.toString(), null, null);
+        logEvent.setMDCPropertyMap(mdc);
+        logEvent.setThreadName("Thread1");
+        logEvent.setCallerData(caller);
+        
+        String customAppName = "otherName";
+        logEvent.setTimeStamp(timeStamp);
+        mdc.put(VCAP_APP_NAME, customAppName);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream os = new PrintStream(baos);
+        this.predixLayout.init(os);
+        this.predixLayout.doEncode(logEvent);
+        String actual = baos.toString();
+        String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
+                + CORRELATION_VALUE + "\",\"appn\":\"" + customAppName + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
+                + "\",\"lvl\":\"" + Level.INFO.toString() + "\",\"msg\":\"\\\"{}\\n,\\\"\\\\\"}";
+        Assert.assertEquals(expected, actual);
+    }
+    
     @Test
     public void testPredixLayoutExceptionLog() throws IOException {
         StackTraceElement[] caller = { new StackTraceElement(CLASS_NAME, METHOD_NAME, FILE_NAME, LINE_NUMBER) };
@@ -126,7 +155,7 @@ public class PredixEncoderTest {
         String actual = baos.toString();
 
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.ERROR.toString()
                 + "\",\"msg\":\"{width=4, length=3, units=inches, height=5}\",\"stck\":"
@@ -166,7 +195,7 @@ public class PredixEncoderTest {
         String actual = baos.toString();
 
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + FILE_NAME
                 + "\",\"lvl\":\"" + Level.ERROR.toString()
                 + "\",\"msg\":\"{width=4, length=3, units=inches, height=5}\",\"stck\":["
@@ -195,7 +224,7 @@ public class PredixEncoderTest {
         this.predixLayout.doEncode(logEvent);
         String actual = baos.toString();
         String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
-                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + CORRELATION_VALUE + "\",\"appn\":\"" + VCAP_APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
                 + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME
                 + "\",\"mod\":\"?\",\"msg\":null}";
         Assert.assertEquals(expected, actual);
@@ -214,7 +243,7 @@ public class PredixEncoderTest {
         HashMap<String, String> mdc = new HashMap<>();
         mdc.put(CORRELATION_HEADER, CORRELATION_VALUE);
         mdc.put(APP_ID, APP_ID_VALUE);
-        mdc.put(APP_NAME, APP_NAME_VALUE);
+        mdc.put(VCAP_APP_NAME, VCAP_APP_NAME_VALUE);
         mdc.put(INSTANCE_ID, INSTANCE_ID_VALUE);
         mdc.put(INSTANCE_INDEX, INSTANCE_INDEX_VALUE);
         mdc.put(ZONE_HEADER, ZONE_VALUE);


### PR DESCRIPTION
Fixing https://rally1.rallydev.com/#/59288075112/detail/defect/120764877144

When integrating log filter with UAA, we had to add a module exclusion for logback dependencies that were added in June. Is there any way to not need this extra configuration?