### PR TITLE
Add support for Log4J 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ This filter initializes an HTTP header(X-B3-TraceID) for tracing, if not already
 
 This information can be used by logging formatters to include in log messages. (see below)
 
-## logback configuration
+## Logback configuration
 
-[PredixEncoder.java](src/main/java/com/ge/predix/logback/PredixEncoder.java) formats the log in JSON and includes the cloudfoundry VCAP info listed in the section above.
+The [`PredixEncoder`](src/main/java/com/ge/predix/logback/PredixEncoder.java) formats the log in JSON and includes the cloudfoundry VCAP info listed in the section above.
 
-* Configure Logback to use PredixEncoder 
+* Configure `logback.xml` to use `PredixEncoder`:
   ```xml
   <appender name="myAppender" class="ch.qos.logback.core.ConsoleAppender">
       <encoder class="com.ge.predix.logback.PredixEncoder">
@@ -101,16 +101,26 @@ This information can be used by logging formatters to include in log messages. (
       </encoder>
   </appender>
   ```
-  * Encoder source -  [PredixEncoder.java](src/main/java/com/ge/predix/logback/PredixEncoder.java)
-  
-## log4j configuration
 
-[PredixLayoutPattern.java](src/main/java/com/ge/predix/log4j1/PredixLayoutPattern.java) formats the log in JSON and includes the cloudfoundry VCAP info listed in the section above.
+## Log4J 1.2 configuration
 
-* Configure log4j.properties to use PredixLayout
+The [`PredixLayout`](src/main/java/com/ge/predix/log4j1/PredixLayout.java) formats the log in JSON and includes the cloudfoundry VCAP info listed in the section above.
+
+* Configure `log4j.properties` to use `PredixLayout`:
   ```
   log4j.appender.CONSOLE.layout=com.ge.predix.log4j1.PredixLayout
   log4j.appender.CONSOLE.messageLineSeparatorRegex=\n //optional
+  ```
+
+## Log4J 2 configuration
+
+The [`PredixLayout`](src/main/java/com/ge/predix/log4j2/PredixLayout.java) formats the log in JSON and includes the cloudfoundry VCAP info listed in the section above.
+
+* Configure `log4j2.xml` to use `PredixLayout`:
+  ```xml
+  <Console name="CONSOLE" target="SYSTEM_OUT">
+      <PredixLayout messageLineSeparatorRegex="\n" />
+  </Console>
   ```
 
 # Multi-line message support

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,13 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.0</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,29 +52,17 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <!-- Dependency Versions -->
-        <commons-lang.version>2.6</commons-lang.version>
-        <spring-core.version>4.1.4.RELEASE</spring-core.version>
-        <spring-data.version>1.9.1.RELEASE</spring-data.version>
-        <spring-test.version>4.1.5.RELEASE</spring-test.version>
+        <spring.version>4.1.4.RELEASE</spring.version>
         <!-- Test Dependency Versions -->
         <mockito.version>1.9.0</mockito.version>
         <testng.version>6.8</testng.version>
     </properties>
+
     <dependencies>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>${commons-lang.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>${spring-core.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>${spring-core.version}</version>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -83,28 +71,8 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>1.2.3</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.5</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.5.0</version>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -115,7 +83,25 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.16.16</version>
+            <scope>provided</scope>
         </dependency>
+
+        <!-- Optional implementations -->
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
         <!-- For Testing -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -132,7 +118,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>${spring-test.version}</version>
+            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/ge/predix/log/filter/LogFilter.java
+++ b/src/main/java/com/ge/predix/log/filter/LogFilter.java
@@ -26,11 +26,11 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.util.StreamUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
@@ -179,7 +179,7 @@ public class LogFilter extends OncePerRequestFilter {
 
     private String setZoneId(final HttpServletRequest request) {
         String zoneId = getZoneId(request);
-        if (StringUtils.isNotEmpty(zoneId)) {
+        if (!StringUtils.isEmpty(zoneId)) {
             MDC.put(ZONE_HEADER_NAME, zoneId);
         }
         return zoneId;

--- a/src/main/java/com/ge/predix/log4j1/PredixLayoutPattern.java
+++ b/src/main/java/com/ge/predix/log4j1/PredixLayoutPattern.java
@@ -27,10 +27,10 @@ import java.util.TimeZone;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.helpers.LogLog;
 import org.apache.log4j.helpers.PatternConverter;
 import org.apache.log4j.spi.LoggingEvent;
+import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;

--- a/src/main/java/com/ge/predix/log4j2/PredixLayout.java
+++ b/src/main/java/com/ge/predix/log4j2/PredixLayout.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright 2020 General Electric Company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.ge.predix.log4j2;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Core;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.layout.AbstractStringLayout;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.springframework.util.StringUtils;
+
+@Plugin(name = "PredixLayout", category = Core.CATEGORY_NAME, elementType = Layout.ELEMENT_TYPE)
+public final class PredixLayout extends AbstractStringLayout {
+
+    private static final StatusLogger STATUS_LOGGER = StatusLogger.getLogger();
+
+    private static final SimpleDateFormat ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    static {
+        ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    private static final ObjectWriter JSON_WRITER = new ObjectMapper().writer();
+
+    private final Pattern messageLineSeparatorPattern;
+
+    private PredixLayout(final Pattern messageLineSeparatorPattern) {
+        super(StandardCharsets.UTF_8);
+        this.messageLineSeparatorPattern = messageLineSeparatorPattern;
+    }
+
+    @PluginFactory
+    public static PredixLayout createLayout(
+            @PluginAttribute("messageLineSeparatorRegex") final String messageLineSeparatorRegex) {
+
+        Pattern messageLineSeparatorRegexPattern = null;
+        if (messageLineSeparatorRegex != null) {
+            try {
+                messageLineSeparatorRegexPattern = Pattern.compile(messageLineSeparatorRegex);
+            } catch (PatternSyntaxException pse) {
+                STATUS_LOGGER.warn("Invalid message line separator: " + pse.getMessage());
+                STATUS_LOGGER.warn("Log message lines will not be separated.");
+            }
+        }
+        return new PredixLayout(messageLineSeparatorRegexPattern);
+    }
+
+    @Override
+    public String toSerializable(final LogEvent event) {
+        // need LinkedHashMap to preserve order of log fields
+        Map<String, Object> logFormat = new LinkedHashMap<>();
+
+        logFormat.put("time", ISO_DATE_FORMAT.format(new Date(event.getTimeMillis())));
+        logFormat.put("tnt", event.getContextData().getValue("Zone-Id"));
+        logFormat.put("corr", event.getContextData().getValue("X-B3-TraceId"));
+        logFormat.put("appn", event.getContextData().getValue("APP_NAME"));
+        logFormat.put("dpmt", event.getContextData().getValue("APP_ID"));
+        logFormat.put("inst", event.getContextData().getValue("INSTANCE_ID"));
+        logFormat.put("tid", event.getThreadName());
+        logFormat.put("mod", event.getLoggerName());
+        if (event.getLevel() != null && event.getLevel() != Level.OFF) {
+            logFormat.put("lvl", event.getLevel().toString());
+        }
+        final Message message = event.getMessage();
+        if (message == null) {
+            logFormat.put("msg", null);
+        } else if (message instanceof ObjectMessage) {
+            logFormat.put("msg", message.getParameters()[0]);
+        } else if (messageLineSeparatorPattern == null) {
+            logFormat.put("msg", message.getFormattedMessage());
+        } else {
+            logFormat.put("msgLines", messageLineSeparatorPattern.split(message.getFormattedMessage()));
+        }
+        if (null != event.getThrown()) {
+            logFormat.put("stck", getStackTrace(event));
+        }
+        try {
+            return JSON_WRITER.writeValueAsString(logFormat) + "\n";
+        } catch (IOException e) {
+            return "Failed to convert log to json for event: " + event.getMessage();
+        }
+    }
+
+    private List<List<String>> getStackTrace(final LogEvent event) {
+        List<List<String>> exceptions = new ArrayList<>();
+        Throwable throwable = event.getThrown();
+        while (throwable != null) {
+            List<String> stack = new ArrayList<>();
+            stack.add(throwable.getClass().getName()
+                    + (!StringUtils.isEmpty(throwable.getMessage()) ? ": " + throwable.getMessage() : ""));
+            for (StackTraceElement element : throwable.getStackTrace()) {
+                stack.add("at " + element.toString());
+            }
+            exceptions.add(stack);
+            throwable = throwable.getCause();
+        }
+
+        return exceptions;
+    }
+}

--- a/src/main/java/com/ge/predix/logback/PredixEncoder.java
+++ b/src/main/java/com/ge/predix/logback/PredixEncoder.java
@@ -29,7 +29,7 @@ import java.util.TimeZone;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.commons.lang.StringUtils;
+import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;

--- a/src/test/java/com/ge/predix/log4j2/PredixLayoutTest.java
+++ b/src/test/java/com/ge/predix/log4j2/PredixLayoutTest.java
@@ -1,0 +1,332 @@
+/*******************************************************************************
+ * Copyright 2020 General Electric Company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.ge.predix.log4j2;
+
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.TimeZone;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.JdkMapAdapterStringMap;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.SimpleMessageFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PredixLayoutTest {
+
+    private static final SimpleDateFormat ISO_DATE_FORMAT;
+    static {
+        ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    private static final String APP_ID = "APP_ID";
+    private static final String APP_NAME = "APP_NAME";
+    private static final String INSTANCE_ID = "INSTANCE_ID";
+    private static final String INSTANCE_INDEX = "INSTANCE_INDEX";
+    private static final String INSTANCE_ID_VALUE = "6758302";
+    private static final String ZONE_VALUE = "test-zone";
+    private static final String INSTANCE_INDEX_VALUE = "5";
+    private static final String APP_NAME_VALUE = "uaa";
+    private static final String APP_ID_VALUE = "098877475";
+    private static final String CORRELATION_VALUE = "5678";
+    private static final String LOGGER_NAME = "com.ge.predix.TestLogger";
+    private static final String THREAD_NAME = "Thread1";
+    private static final String CORRELATION_HEADER = "X-B3-TraceId";
+    private static final String ZONE_HEADER = "Zone-Id";
+
+    private static final Message OBJECT_MESSAGE = SimpleMessageFactory.INSTANCE.newMessage(buildObjectMessage());
+    private static final Message MULTI_LINE_TEXT_MESSAGE = SimpleMessageFactory.INSTANCE.newMessage(
+            "L1\nL2" + System.lineSeparator() + "L3");
+
+    private final PredixLayout predixLayout = PredixLayout.createLayout(null);
+
+    @Test
+    public void testPredixLayoutRegularLog() {
+        long timeStamp = Instant.now().toEpochMilli();
+        String expectedTimeStamp = ISO_DATE_FORMAT.format(new Date(timeStamp));
+        HashMap<String, String> mdc = getMDC();
+        LogEvent logEvent = Log4jLogEvent.newBuilder()
+                .setLoggerName(LOGGER_NAME)
+                .setTimeMillis(timeStamp)
+                .setLevel(Level.INFO)
+                .setMessage(OBJECT_MESSAGE)
+                .setThreadName(THREAD_NAME)
+                .setContextData(new JdkMapAdapterStringMap(mdc))
+                .build();
+        String actual = predixLayout.toSerializable(logEvent);
+        String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + LOGGER_NAME
+                + "\",\"lvl\":\"" + Level.INFO.toString()
+                + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5}}\n";
+        System.out.println(actual);
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPredixLayoutSpecialCharsLog() {
+        long timeStamp = Instant.now().toEpochMilli();
+        String expectedTimeStamp = ISO_DATE_FORMAT.format(new Date(timeStamp));
+        HashMap<String, String> mdc = getMDC();
+        HashMap<String, Object> msg = new HashMap<>();
+        msg.put("quote", '"');
+        msg.put("backslash", (char) 92);
+        LogEvent logEvent = Log4jLogEvent.newBuilder()
+                .setLoggerName(LOGGER_NAME)
+                .setTimeMillis(timeStamp)
+                .setLevel(Level.INFO)
+                .setMessage(SimpleMessageFactory.INSTANCE.newMessage(msg))
+                .setThreadName(THREAD_NAME)
+                .setContextData(new JdkMapAdapterStringMap(mdc))
+                .build();
+        String actual = predixLayout.toSerializable(logEvent);
+        String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + LOGGER_NAME
+                + "\",\"lvl\":\"" + Level.INFO.toString() + "\",\"msg\":{\"quote\":\"\\\"\",\"backslash\":\"\\\\\"}}\n";
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPredixLayoutExceptionLog() {
+        long timeStamp = Instant.now().toEpochMilli();
+        String expectedTimeStamp = ISO_DATE_FORMAT.format(new Date(timeStamp));
+        HashMap<String, String> mdc = getMDC();
+        Throwable exceptionThrowable = new Exception();
+        exceptionThrowable.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement("com.ge.predix.some.package.Class", "method", "Class.java", 234),
+                new StackTraceElement("com.ge.predix.some.other.package.OtherClass", "diffMethod", "OtherClass.java",
+                        45) });
+
+        LogEvent logEvent = Log4jLogEvent.newBuilder()
+                .setLoggerName(LOGGER_NAME)
+                .setTimeMillis(timeStamp)
+                .setLevel(Level.ERROR)
+                .setMessage(OBJECT_MESSAGE)
+                .setThreadName(THREAD_NAME)
+                .setContextData(new JdkMapAdapterStringMap(mdc))
+                .setThrown(exceptionThrowable)
+                .build();
+        String actual = predixLayout.toSerializable(logEvent);
+        String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + LOGGER_NAME
+                + "\",\"lvl\":\"" + Level.ERROR.toString()
+                + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5},\"stck\":"
+                + "[[\"java.lang.Exception\",\"at com.ge.predix.some.package.Class.method(Class.java:234)\",\""
+                + "at com.ge.predix.some.other.package.OtherClass.diffMethod(OtherClass.java:45)\"]]}\n";
+        Assert.assertEquals(actual, expected);
+        // check that a logEvent without a stack trace is not polluted from previous logEvent with a stack trace.
+        logEvent = Log4jLogEvent.newBuilder()
+                .setLoggerName(LOGGER_NAME)
+                .setTimeMillis(timeStamp)
+                .setLevel(Level.INFO)
+                .setMessage(OBJECT_MESSAGE)
+                .setThreadName(THREAD_NAME)
+                .setContextData(new JdkMapAdapterStringMap(mdc))
+                .build();
+        actual = predixLayout.toSerializable(logEvent);
+        expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + LOGGER_NAME
+                + "\",\"lvl\":\"" + Level.INFO.toString()
+                + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5}}\n";
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPredixLayoutExceptionChainLog() {
+
+        long timeStamp = Instant.now().toEpochMilli();
+        String expectedTimeStamp = ISO_DATE_FORMAT.format(new Date(timeStamp));
+        HashMap<String, String> mdc = getMDC();
+        Throwable exceptionCause = new NullPointerException("example NullPointerException");
+        exceptionCause.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement("com.ge.predix.some.package.Class", "method", "Class.java", 234),
+                new StackTraceElement("com.ge.predix.some.other.package.OtherClass", "diffMethod", "OtherClass.java",
+                        45) });
+        Throwable exceptionRoot = new Exception(exceptionCause);
+        exceptionRoot.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement("com.ge.predix.some.package.Clazz", "method", "Clazz.java", 473),
+                new StackTraceElement("com.ge.predix.some.other.package.OtherClazz", "diffMethod", "OtherClazz.java",
+                        55) });
+
+        LogEvent logEvent = Log4jLogEvent.newBuilder()
+                .setLoggerName(LOGGER_NAME)
+                .setTimeMillis(timeStamp)
+                .setLevel(Level.ERROR)
+                .setMessage(OBJECT_MESSAGE)
+                .setThreadName(THREAD_NAME)
+                .setContextData(new JdkMapAdapterStringMap(mdc))
+                .setThrown(exceptionRoot)
+                .build();
+        String actual = predixLayout.toSerializable(logEvent);
+
+        String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME + "\",\"mod\":\"" + LOGGER_NAME
+                + "\",\"lvl\":\"" + Level.ERROR.toString()
+                + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5},\"stck\":["
+                + "[\"java.lang.Exception: java.lang.NullPointerException: example NullPointerException\","
+                + "\"at com.ge.predix.some.package.Clazz.method(Clazz.java:473)\","
+                + "\"at com.ge.predix.some.other.package.OtherClazz.diffMethod(OtherClazz.java:55)\"],"
+                + "[\"java.lang.NullPointerException: example NullPointerException\","
+                + "\"at com.ge.predix.some.package.Class.method(Class.java:234)\","
+                + "\"at com.ge.predix.some.other.package.OtherClass.diffMethod(OtherClass.java:45)\"]]}\n";
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPredixLayoutMissingInfoLog() {
+        long timeStamp = Instant.now().toEpochMilli();
+        String expectedTimeStamp = ISO_DATE_FORMAT.format(new Date(timeStamp));
+        HashMap<String, String> mdc = getMDC();
+        LogEvent logEvent = Log4jLogEvent.newBuilder()
+                .setTimeMillis(timeStamp)
+                .setThreadName(THREAD_NAME)
+                .setContextData(new JdkMapAdapterStringMap(mdc))
+                .build();
+        String actual = predixLayout.toSerializable(logEvent);
+        System.out.println(actual);
+        String expected = "{\"time\":\"" + expectedTimeStamp + "\",\"tnt\":\"" + ZONE_VALUE + "\",\"corr\":\""
+                + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE + "\",\"dpmt\":\"" + APP_ID_VALUE
+                + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME
+                + "\",\"mod\":null,\"msg\":null}\n";
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPredixEncoderWithNoMessageLineSeparator() {
+
+        LogEvent input = createLogEvent(MULTI_LINE_TEXT_MESSAGE);
+
+        String expected = "{\"time\":\"" + ISO_DATE_FORMAT.format(new Date(input.getTimeMillis())) + "\",\"tnt\":\""
+                + ZONE_VALUE + "\",\"corr\":\"" + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE
+                + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME
+                + "\",\"mod\":\"" + LOGGER_NAME + "\",\"lvl\":\"" + Level.INFO + "\",\"msg\":\"L1\\nL2\\nL3\"}\n";
+
+        PredixLayout multiLinePredixLayout = PredixLayout.createLayout(null);
+        String actual = multiLinePredixLayout.toSerializable(input);
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPredixEncoderWithInvalidMessageLineSeparator() {
+
+        LogEvent input = createLogEvent(MULTI_LINE_TEXT_MESSAGE);
+
+        // If an invalid regex is detected, the layout will switch it off.
+        String expected = "{\"time\":\"" + ISO_DATE_FORMAT.format(new Date(input.getTimeMillis())) + "\",\"tnt\":\""
+                + ZONE_VALUE + "\",\"corr\":\"" + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE
+                + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME
+                + "\",\"mod\":\"" + LOGGER_NAME + "\",\"lvl\":\"" + Level.INFO + "\",\"msg\":\"L1\\nL2\\nL3\"}\n";
+
+        PredixLayout multiLinePredixLayout = PredixLayout.createLayout("("); // Malformed regex
+        String actual = multiLinePredixLayout.toSerializable(input);
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPredixEncoderWithSimpleMessageLineSeparator() {
+
+        LogEvent input = createLogEvent(MULTI_LINE_TEXT_MESSAGE);
+
+        String expected = "{\"time\":\"" + ISO_DATE_FORMAT.format(new Date(input.getTimeMillis())) + "\",\"tnt\":\""
+                + ZONE_VALUE + "\",\"corr\":\"" + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE
+                + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME
+                + "\",\"mod\":\"" + LOGGER_NAME + "\",\"lvl\":\"" + Level.INFO
+                + "\",\"msgLines\":[\"L1\",\"L2\",\"L3\"]}\n";
+
+        PredixLayout multiLinePredixLayout = PredixLayout.createLayout(System.lineSeparator());
+        String actual = multiLinePredixLayout.toSerializable(input);
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPredixEncoderWithRegexMessageLineSeparator() {
+
+        LogEvent input = createLogEvent(MULTI_LINE_TEXT_MESSAGE);
+
+        String expected = "{\"time\":\"" + ISO_DATE_FORMAT.format(new Date(input.getTimeMillis())) + "\",\"tnt\":\""
+                + ZONE_VALUE + "\",\"corr\":\"" + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE
+                + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME
+                + "\",\"mod\":\"" + LOGGER_NAME + "\",\"lvl\":\"" + Level.INFO + "\",\"msgLines\":[\"L\",\"L\",\"L\"]}\n";
+
+        PredixLayout multiLinePredixLayout = PredixLayout.createLayout("[0-9]+\n?");
+        String actual = multiLinePredixLayout.toSerializable(input);
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPredixEncoderWithNonStringMessageAndMessageLineSeparator() {
+
+        // When something other than a String is logged, the message line separator has no effect.
+        LogEvent input = createLogEvent(OBJECT_MESSAGE);
+
+        String expected = "{\"time\":\"" + ISO_DATE_FORMAT.format(new Date(input.getTimeMillis())) + "\",\"tnt\":\""
+                + ZONE_VALUE + "\",\"corr\":\"" + CORRELATION_VALUE + "\",\"appn\":\"" + APP_NAME_VALUE
+                + "\",\"dpmt\":\"" + APP_ID_VALUE + "\",\"inst\":\"" + INSTANCE_ID_VALUE + "\",\"tid\":\"" + THREAD_NAME
+                + "\",\"mod\":\"" + LOGGER_NAME + "\",\"lvl\":\"" + Level.INFO.toString()
+                + "\",\"msg\":{\"width\":4,\"length\":3,\"units\":\"inches\",\"height\":5}}\n";
+
+        PredixLayout multiLinePredixLayout = PredixLayout.createLayout(System.lineSeparator());
+        String actual = multiLinePredixLayout.toSerializable(input);
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    private static LogEvent createLogEvent(final Message message) {
+        return Log4jLogEvent.newBuilder()
+                .setLoggerName(LOGGER_NAME)
+                .setTimeMillis(Instant.now().toEpochMilli())
+                .setLevel(Level.INFO)
+                .setMessage(message)
+                .setThreadName(THREAD_NAME)
+                .setContextData(new JdkMapAdapterStringMap(getMDC()))
+                .build();
+    }
+
+    private static HashMap<String, Object> buildObjectMessage() {
+        HashMap<String, Object> msg = new HashMap<>();
+        msg.put("height", 5);
+        msg.put("width", 4);
+        msg.put("length", 3);
+        msg.put("units", "inches");
+        return msg;
+    }
+
+    private static HashMap<String, String> getMDC() {
+        HashMap<String, String> mdc = new HashMap<>();
+        mdc.put(CORRELATION_HEADER, CORRELATION_VALUE);
+        mdc.put(APP_ID, APP_ID_VALUE);
+        mdc.put(APP_NAME, APP_NAME_VALUE);
+        mdc.put(INSTANCE_ID, INSTANCE_ID_VALUE);
+        mdc.put(INSTANCE_INDEX, INSTANCE_INDEX_VALUE);
+        mdc.put(ZONE_HEADER, ZONE_VALUE);
+        return mdc;
+    }
+}


### PR DESCRIPTION
Notes:
- The new Log4J 2 implementation matches the behavior of the older Log4J 1.2 implementation exactly.
- This requires some special-cased code which changes the behavior of the new framework.
- Unit tests are copied 1:1 from the older implementation, including method names and implementation, to ensure compatibility.

Future discussions (next major release):
- Can we remove special-casing and change the behavior to match Log4J 2 defaults?
- Can we remove the Log4J 1.2 implementation?
- Can we split this library into "core" and multiple "*-impl" modules to avoid pulling in unnecessary classes?